### PR TITLE
Add backlog tickets from design review

### DIFF
--- a/logs/activity.log
+++ b/logs/activity.log
@@ -70,3 +70,4 @@ Sat Jul 12 13:00:39 UTC 2025 - Marked Ticket 9 as Started
 Sat Jul 12 13:01:32 UTC 2025 - Installed dependencies and ran pytest
 Sat Jul 12 13:01:35 UTC 2025 - Marked Ticket 9 as Coded, Tested, Documented
 Sat Jul 12 13:01:39 UTC 2025 - Marked Ticket 9 as Reviewed
+Sat Jul 12 13:15:30 UTC 2025 - Created new tickets 14-28 from design and log review

--- a/tickets.md
+++ b/tickets.md
@@ -142,3 +142,165 @@
 - Integrate pathfinding into `NPC.move` when a path is required.
 - Add tests in `tests/test_pathfinding.py` for path generation and obstacles.
 - Document in `docs/pathfinding.md`.
+## Ticket 14 - Settlements and Ruins Generation
+- [ ] Started
+- [ ] Coded
+- [ ] Tested
+- [ ] Reviewed
+- [ ] Documented
+- Extend `worldgen` with placement of villages, castles, ruins and trade posts.
+- Include special "megalith" tiles that are mostly indestructible.
+- Write tests ensuring settlements appear when a seed is used.
+- Document in `docs/worldgen_settlements.md`.
+
+## Ticket 15 - Destructible Tiles and Grouping
+- [ ] Started
+- [ ] Coded
+- [ ] Tested
+- [ ] Reviewed
+- [ ] Documented
+- Add support for marking tiles as destructible or permanent.
+- Implement grouping of tiles into structures (houses, mountains, ships).
+- Update tests to cover new attributes and grouping behavior.
+- Document in `docs/tile_groups.md`.
+
+## Ticket 16 - Expanded Item Definitions
+- [ ] Started
+- [ ] Coded
+- [ ] Tested
+- [ ] Reviewed
+- [ ] Documented
+- Move item and recipe data to JSON files loaded at runtime.
+- Include base and intermediate materials from the design document.
+- Add fields for quality, rarity and impressiveness.
+- Document format in `docs/items_json.md`.
+
+## Ticket 17 - Equipment Slots
+- [ ] Started
+- [ ] Coded
+- [ ] Tested
+- [ ] Reviewed
+- [ ] Documented
+- Extend `Item` and `Inventory` to handle equip slots (hand, head, torso, feet, etc.).
+- Provide tests for equipping and unequipping items.
+- Document in `docs/equipment.md`.
+
+## Ticket 18 - Basic Combat System
+- [ ] Started
+- [ ] Coded
+- [ ] Tested
+- [ ] Reviewed
+- [ ] Documented
+- Create combat functions for melee and ranged attacks using item stats.
+- Track health reduction and simple hit chance.
+- Add unit tests for combat calculations.
+- Document usage in `docs/combat.md`.
+
+## Ticket 19 - NPC Needs System
+- [ ] Started
+- [ ] Coded
+- [ ] Tested
+- [ ] Reviewed
+- [ ] Documented
+- Expand NPC class with needs for rest, safety, social and status.
+- Implement periodic decay and satisfaction methods.
+- Add tests verifying needs update over time.
+- Document in `docs/npc_needs.md`.
+
+## Ticket 20 - NPC Personalities and Factions
+- [ ] Started
+- [ ] Coded
+- [ ] Tested
+- [ ] Reviewed
+- [ ] Documented
+- Add personality traits and emotional states to NPCs.
+- Implement simple faction/group membership.
+- Provide tests for trait assignment and group storage.
+- Document in `docs/npc_personality.md`.
+
+## Ticket 21 - Basic AI Behaviors
+- [ ] Started
+- [ ] Coded
+- [ ] Tested
+- [ ] Reviewed
+- [ ] Documented
+- Introduce behavior routines such as wandering, working and socializing.
+- Use pathfinding to move toward goals or resources.
+- Add unit tests for behavior selection logic.
+- Document in `docs/ai_behavior.md`.
+
+## Ticket 22 - Story Anchor Framework
+- [ ] Started
+- [ ] Coded
+- [ ] Tested
+- [ ] Reviewed
+- [ ] Documented
+- Create data structures for hard and soft story goals.
+- Implement an event system that triggers anchors based on world state.
+- Write tests for anchor activation logic.
+- Document in `docs/story_anchors.md`.
+
+## Ticket 23 - LLM Storytelling Integration
+- [ ] Started
+- [ ] Coded
+- [ ] Tested
+- [ ] Reviewed
+- [ ] Documented
+- Set up a stub interface for optional LLM-driven dialogue and quests.
+- Allow disabling LLM features when no model is present.
+- Add basic unit tests with mocked responses.
+- Document setup in `docs/llm_integration.md`.
+
+## Ticket 24 - Expanded Save/Load
+- [ ] Started
+- [ ] Coded
+- [ ] Tested
+- [ ] Reviewed
+- [ ] Documented
+- Extend the save system to include story state and NPC factions.
+- Ensure backward compatibility with existing saves.
+- Write tests for the new data fields.
+- Update documentation in `docs/save_load.md`.
+
+## Ticket 25 - UI Inventory and Menu Screens
+- [ ] Started
+- [ ] Coded
+- [ ] Tested
+- [ ] Reviewed
+- [ ] Documented
+- Build Godot scenes for inventory management and a main menu.
+- Hook up the Player inventory to display item icons.
+- Provide manual test steps until automated UI tests are in place.
+- Document in `docs/ui_inventory.md`.
+
+## Ticket 26 - Asset Pipeline Setup
+- [ ] Started
+- [ ] Coded
+- [ ] Tested
+- [ ] Reviewed
+- [ ] Documented
+- Create script for generating placeholder sprites via Stable Diffusion or OpenGameArt assets.
+- Organize assets under an `assets/` directory with subfolders for tiles and characters.
+- Document the asset workflow in `docs/assets.md`.
+
+## Ticket 27 - Modding Support Basics
+- [ ] Started
+- [ ] Coded
+- [ ] Tested
+- [ ] Reviewed
+- [ ] Documented
+- Define a mod loading system for custom items and maps via JSON packages.
+- Provide example mod files and loading logic.
+- Add tests for mod discovery and parsing.
+- Document usage in `docs/modding.md`.
+
+## Ticket 28 - Advanced Logging Options
+- [ ] Started
+- [ ] Coded
+- [ ] Tested
+- [ ] Reviewed
+- [ ] Documented
+- Enhance `logging_util` with log rotation and console output.
+- Allow configuration via a file or environment variables.
+- Add tests covering new logging features.
+- Update documentation in `docs/logging_util.md`.


### PR DESCRIPTION
## Summary
- add backlog items based on design.md
- log ticket creation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68725f586e04833298d6f7d6cdb777be