### PR TITLE
Add planning document for milestone tracking

### DIFF
--- a/logs/activity.log
+++ b/logs/activity.log
@@ -80,3 +80,7 @@ Sat Jul 12 13:34:14 UTC 2025 - Implemented basic features for tickets 19-28
 Sat Jul 12 13:34:32 UTC 2025 - Ran pytest for tickets 19-28
 Sat Jul 12 13:39:34 UTC 2025 - Reviewing design and logs to create new tickets
 Sat Jul 12 13:39:35 UTC 2025 - Added tickets 29-48 for missing features
+Sat Jul 12 13:47:02 UTC 2025 - Started Ticket 49: Planning Document
+Sat Jul 12 13:47:05 UTC 2025 - Created planning.md with milestones
+Sat Jul 12 13:47:06 UTC 2025 - Updated tickets for Ticket 49
+Sat Jul 12 13:47:21 UTC 2025 - Ran pytest for Ticket 49

--- a/planning.md
+++ b/planning.md
@@ -1,0 +1,43 @@
+# Development Planning
+
+This document tracks feature milestones and planned tasks to help coordinate development. Refer to `tickets.md` for issue details and `design.md` for overall vision.
+
+## Completed Features
+
+- [x] Project setup and folder structure
+- [x] Workflow guidelines in `AGENTS.md`
+- [x] World generation prototype
+- [x] Item and inventory system
+- [x] Basic NPC class with movement
+- [x] Player class with inventory
+- [x] Map handling and pathfinding
+- [x] Crafting system
+- [x] Save and load functionality
+- [x] Command line seed option
+- [x] Logging utility
+- [x] Combat helpers
+- [x] NPC needs and personality traits
+- [x] AI behaviors and story anchors
+- [x] Modding support and asset generation
+- [x] Optional LLM integration
+
+## Roadmap and Milestones
+
+### Step 4 – Story and Events
+- [ ] Procedural quest generator
+- [ ] Expanded event system
+
+### Step 5 – Visuals and UI
+- [ ] Art palette and layered sprites
+- [ ] UI style pass and additional screens
+- [ ] NPC animation states
+
+### Step 6 – Advanced Systems
+- [ ] Faction goals and group AI
+- [ ] Offline LLM integration
+- [ ] Weather and seasons
+- [ ] Trading and economy
+- [ ] NPC families and relationships
+- [ ] Nested containers and volume limits
+
+Use the checkboxes to monitor progress as features are completed.

--- a/tickets.md
+++ b/tickets.md
@@ -471,3 +471,11 @@
 - [ ] Documented
 - Implement a day/night cycle and energy stat affecting actions.
 
+
+## Ticket 49 - Planning Document
+- [x] Started
+- [x] Coded
+- [x] Tested
+- [x] Reviewed
+- [x] Documented
+- Create planning.md summarizing completed features and future milestones.


### PR DESCRIPTION
## Summary
- add `planning.md` outlining completed features and future milestones
- record activity in `logs/activity.log`
- add Ticket 49 for creating the planning document

## Testing
- `pip install noise`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687266c828108332aba28d959514eb48