### PR TITLE
Add UI pack asset download

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ and [docs/story_anchors.md](docs/story_anchors.md).
 
 Mods can be placed under `mods/` and loaded using `modding.discover_mods`. Run
 `scripts/generate_assets.py` to create placeholder assets. See
-The helper in `asset_manager.ensure_assets` downloads Kenney asset packs at runtime and saves only their file names in `assets/asset_index.json`.
+The helper in `asset_manager.ensure_assets` downloads Kenney asset packs (environment, characters and UI) at runtime and saves only their file names in `assets/asset_index.json`.
 [docs/modding.md](docs/modding.md) and [docs/assets.md](docs/assets.md).
 
 ### LLM Integration

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -17,6 +17,7 @@ from asset_manager import ensure_assets
 ASSETS = {
     'tiny-town': 'https://kenney.nl/media/pages/assets/tiny-town/5e46f9e551-1735736916/kenney_tiny-town.zip',
     'roguelike-characters': 'https://kenney.nl/media/pages/assets/roguelike-characters/dbeea49dc8-1729196490/kenney_roguelike-characters.zip',
+    'ui-pack-rpg-expansion': 'https://kenney.nl/media/pages/assets/ui-pack-rpg-expansion/885ad5ccc0-1677661824/kenney_ui-pack-rpg-expansion.zip',
 }
 
 ensure_assets(ASSETS)

--- a/logs/activity.log
+++ b/logs/activity.log
@@ -105,3 +105,6 @@ Sat Jul 12 14:26:27 UTC 2025 - Ran pytest after Godot migration
 Sat Jul 12 14:37:17 UTC 2025 - Starting Ticket 7: Runtime Asset Download
 Sat Jul 12 14:37:18 UTC 2025 - Implemented asset_manager module and tests
 Sat Jul 12 14:37:20 UTC 2025 - Documented runtime asset downloads
+Sat Jul 12 14:43:42 UTC 2025 - Starting Ticket 61: UI Asset Pack
+Sat Jul 12 14:43:43 UTC 2025 - Added UI asset pack entry and tests
+Sat Jul 12 14:43:44 UTC 2025 - Ran pytest

--- a/planning.md
+++ b/planning.md
@@ -35,6 +35,7 @@ This document tracks feature milestones and planned tasks to help coordinate dev
 - [x] Visual assets are downloaded at runtime.
 - [ ] environment: https://kenney.nl/media/pages/assets/tiny-town/5e46f9e551-1735736916/kenney_tiny-town.zip
 - [ ] characters: https://kenney.nl/media/pages/assets/roguelike-characters/dbeea49dc8-1729196490/kenney_roguelike-characters.zip
+- [ ] ui: https://kenney.nl/media/pages/assets/ui-pack-rpg-expansion/885ad5ccc0-1677661824/kenney_ui-pack-rpg-expansion.zip
 - [ ] Create a system for the characters using the assets: https://kenney.nl/assets/roguelike-characters
 - [ ] Map the tilset from: https://kenney.nl/assets/tiny-town to our map generator
 - [ ] Art palette and layered sprites

--- a/tests/test_asset_manager.py
+++ b/tests/test_asset_manager.py
@@ -32,3 +32,39 @@ def test_download_and_index_local_zip(tmp_path, monkeypatch):
     assert 'testpack' in data
     assert 'file1.png' in data['testpack']
     assert 'folder/file2.png' in data['testpack']
+
+
+def test_ensure_assets_multiple(tmp_path, monkeypatch):
+    db_path = tmp_path / 'assets.json'
+    temp_dir = tmp_path / 'tmp'
+    monkeypatch.setenv('ASSET_DB', str(db_path))
+    monkeypatch.setenv('ASSET_TEMP', str(temp_dir))
+
+    import importlib
+    import asset_manager
+    asset_manager = importlib.reload(asset_manager)
+
+    zip1 = tmp_path / 'ui.zip'
+    with zipfile.ZipFile(zip1, 'w') as zf:
+        zf.writestr('ui/button.png', 'data')
+
+    zip2 = tmp_path / 'env.zip'
+    with zipfile.ZipFile(zip2, 'w') as zf:
+        zf.writestr('env/tile.png', 'data')
+
+    assets = {'ui': f'file://{zip1}', 'env': f'file://{zip2}'}
+    asset_manager.ensure_assets(assets)
+
+    assert not (temp_dir / 'ui.zip').exists()
+    assert not (temp_dir / 'env.zip').exists()
+    with open(db_path) as f:
+        data = json.load(f)
+    assert set(data.keys()) == {'ui', 'env'}
+    assert 'ui/button.png' in data['ui']
+    assert 'env/tile.png' in data['env']
+
+    def fail(*args, **kwargs):
+        raise RuntimeError('should not download again')
+
+    monkeypatch.setattr(asset_manager, 'download_and_index', fail)
+    asset_manager.ensure_assets(assets)

--- a/tickets.md
+++ b/tickets.md
@@ -562,3 +562,11 @@ Document in `docs/equipment.md`.
 - [x] Reviewed
 - [x] Documented
 - Replace Perlin noise world generator with wave function collapse algorithm.
+
+## Ticket 61 - UI Asset Pack
+- [ ] Started
+- [ ] Coded
+- [ ] Tested
+- [ ] Reviewed
+- [ ] Documented
+Add the Kenney UI Pack RPG Expansion as a runtime-downloadable asset. Index its file list in the asset database.


### PR DESCRIPTION
## Summary
- add Kenney UI pack RPG Expansion as runtime asset
- document new asset pack in README, planning, and assets guide
- add ticket for UI asset pack
- extend asset manager tests for multi-pack download

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687273f4b18c83329960d6dd2357e0a5