### PR TITLE
Refactor package imports and tests

### DIFF
--- a/logs/activity.log
+++ b/logs/activity.log
@@ -117,3 +117,4 @@ Sat Jul 12 15:24:16 UTC 2025 - Ran pytest
 Sat Jul 12 15:28:42 UTC 2025 - Starting Tickets 22, 23, 24 and 31
 Sat Jul 12 15:30:01 UTC 2025 - Implemented tickets 22, 23, 24, 31
 Sat Jul 12 15:30:18 UTC 2025 - Ran pytest
+Sat Jul 12 15:49:26 UTC 2025 - Refactored codebase, updated imports and tests

--- a/src/ai_behavior.py
+++ b/src/ai_behavior.py
@@ -3,8 +3,9 @@ from enum import Enum
 from random import choice
 from typing import Optional
 
-from npc import NPC
-from game_map import GameMap
+from .npc import NPC
+from .game_map import GameMap
+
 
 class Behavior(Enum):
     IDLE = "idle"
@@ -22,7 +23,9 @@ def select_behavior(npc: NPC) -> Behavior:
     return Behavior.IDLE
 
 
-def perform_behavior(npc: NPC, behavior: Behavior, game_map: Optional[GameMap] = None) -> None:
+def perform_behavior(
+    npc: NPC, behavior: Behavior, game_map: Optional[GameMap] = None
+) -> None:
     """Execute one tick of the behavior."""
     if behavior == Behavior.WANDER:
         npc.move(choice([-1, 0, 1]), choice([-1, 0, 1]), game_map)

--- a/src/asset_manager.py
+++ b/src/asset_manager.py
@@ -11,31 +11,33 @@ except ImportError:  # in case requests isn't installed when imported
 
 
 # Directories can be overridden for tests via environment variables
-ASSET_DIR = os.path.join(os.path.dirname(__file__), '..', 'assets')
-ASSET_DB = os.environ.get('ASSET_DB', os.path.join(ASSET_DIR, 'asset_index.json'))
-TEMP_DIR = os.environ.get('ASSET_TEMP', os.path.join(ASSET_DIR, 'temp'))
+ASSET_DIR = os.path.join(os.path.dirname(__file__), "..", "assets")
+ASSET_DB = os.environ.get(
+    "ASSET_DB", os.path.join(ASSET_DIR, "asset_index.json")
+)
+TEMP_DIR = os.environ.get("ASSET_TEMP", os.path.join(ASSET_DIR, "temp"))
 
 # Default Kenney asset packs used by the project. These URLs are indexed at
 # runtime using :func:`ensure_assets`. They can be overridden in tests by
 # monkeypatching this dictionary.
 DEFAULT_ASSETS = {
-    'tiny-town': 'https://kenney.nl/media/pages/assets/tiny-town/5e46f9e551-1735736916/kenney_tiny-town.zip',
-    'roguelike-characters': 'https://kenney.nl/media/pages/assets/roguelike-characters/dbeea49dc8-1729196490/kenney_roguelike-characters.zip',
-    'ui-pack-rpg-expansion': 'https://kenney.nl/media/pages/assets/ui-pack-rpg-expansion/885ad5ccc0-1677661824/kenney_ui-pack-rpg-expansion.zip',
+    "tiny-town": "https://kenney.nl/media/pages/assets/tiny-town/5e46f9e551-1735736916/kenney_tiny-town.zip",
+    "roguelike-characters": "https://kenney.nl/media/pages/assets/roguelike-characters/dbeea49dc8-1729196490/kenney_roguelike-characters.zip",
+    "ui-pack-rpg-expansion": "https://kenney.nl/media/pages/assets/ui-pack-rpg-expansion/885ad5ccc0-1677661824/kenney_ui-pack-rpg-expansion.zip",
 }
 
 
 def _download(url: str, dest: str) -> None:
     parsed = urlparse(url)
     os.makedirs(os.path.dirname(dest), exist_ok=True)
-    if parsed.scheme == 'file':
+    if parsed.scheme == "file":
         shutil.copyfile(parsed.path, dest)
     else:
         if requests is None:
-            raise RuntimeError('requests is required to download assets')
+            raise RuntimeError("requests is required to download assets")
         response = requests.get(url, stream=True)
         response.raise_for_status()
-        with open(dest, 'wb') as f:
+        with open(dest, "wb") as f:
             for chunk in response.iter_content(chunk_size=8192):
                 f.write(chunk)
 
@@ -44,19 +46,19 @@ def download_and_index(name: str, url: str) -> None:
     """Download a zip file, record its contents to the asset DB, then delete."""
     os.makedirs(TEMP_DIR, exist_ok=True)
     os.makedirs(os.path.dirname(ASSET_DB), exist_ok=True)
-    zip_path = os.path.join(TEMP_DIR, f'{name}.zip')
+    zip_path = os.path.join(TEMP_DIR, f"{name}.zip")
     _download(url, zip_path)
 
-    with zipfile.ZipFile(zip_path, 'r') as zf:
+    with zipfile.ZipFile(zip_path, "r") as zf:
         files = [info.filename for info in zf.infolist()]
 
     if os.path.exists(ASSET_DB):
-        with open(ASSET_DB, 'r') as f:
+        with open(ASSET_DB, "r") as f:
             data = json.load(f)
     else:
         data = {}
     data[name] = files
-    with open(ASSET_DB, 'w') as f:
+    with open(ASSET_DB, "w") as f:
         json.dump(data, f, indent=2)
 
     os.remove(zip_path)
@@ -66,7 +68,7 @@ def ensure_assets(assets: dict) -> None:
     """Ensure each asset pack is indexed. assets is {name: url}."""
     existing = {}
     if os.path.exists(ASSET_DB):
-        with open(ASSET_DB, 'r') as f:
+        with open(ASSET_DB, "r") as f:
             existing = json.load(f)
 
     for name, url in assets.items():

--- a/src/combat.py
+++ b/src/combat.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import random
-from item import Item
-from npc import NPC
+from .item import Item
+from .npc import NPC
 
 
 def _damage_from_item(item: Item) -> int:
@@ -10,7 +10,9 @@ def _damage_from_item(item: Item) -> int:
     return max(1, int(item.weight))
 
 
-def melee_attack(attacker: NPC, defender: NPC, weapon: Item, hit_chance: float = 0.8) -> bool:
+def melee_attack(
+    attacker: NPC, defender: NPC, weapon: Item, hit_chance: float = 0.8
+) -> bool:
     """Perform a melee attack. Returns True on hit."""
     if random.random() <= hit_chance:
         defender.health = max(0, defender.health - _damage_from_item(weapon))
@@ -19,7 +21,9 @@ def melee_attack(attacker: NPC, defender: NPC, weapon: Item, hit_chance: float =
     return False
 
 
-def ranged_attack(attacker: NPC, defender: NPC, weapon: Item, hit_chance: float = 0.6) -> bool:
+def ranged_attack(
+    attacker: NPC, defender: NPC, weapon: Item, hit_chance: float = 0.6
+) -> bool:
     """Perform a ranged attack. Returns True on hit."""
     if random.random() <= hit_chance:
         defender.health = max(0, defender.health - _damage_from_item(weapon))

--- a/src/crafting.py
+++ b/src/crafting.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
 from typing import Dict, Optional
 
-from item import Item, Inventory
+from .item import Item, Inventory
+
 
 @dataclass
 class Recipe:

--- a/src/game_map.py
+++ b/src/game_map.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import List
 
+
 @dataclass
 class GameMap:
     width: int

--- a/src/item.py
+++ b/src/item.py
@@ -1,15 +1,17 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import List, Optional
+
 
 @dataclass
 class Item:
     """A basic item with minimal stats."""
+
     name: str
     weight: float = 0.0
     volume: float = 0.0
     durability: int = 100
     max_volume: Optional[float] = None
-    contents: Optional['Inventory'] = None
+    contents: Optional["Inventory"] = None
 
 
 class Inventory:

--- a/src/logging_util.py
+++ b/src/logging_util.py
@@ -3,7 +3,10 @@ import os
 from logging import Logger
 from logging.handlers import RotatingFileHandler
 
-def create_logger(name: str, level: str = "INFO", file_path: str = "game.log") -> Logger:
+
+def create_logger(
+    name: str, level: str = "INFO", file_path: str = "game.log"
+) -> Logger:
     """Create and configure a logger.
 
     Parameters

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 import argparse
-from worldgen import generate_map
+from .worldgen import generate_map
 
 
 def parse_args(args=None):

--- a/src/modding.py
+++ b/src/modding.py
@@ -11,7 +11,7 @@ class Mod:
     maps: List[dict]
 
 
-MOD_DIR = os.path.join(os.path.dirname(__file__), '..', 'mods')
+MOD_DIR = os.path.join(os.path.dirname(__file__), "..", "mods")
 
 
 def discover_mods() -> List[Mod]:
@@ -19,9 +19,15 @@ def discover_mods() -> List[Mod]:
     if not os.path.isdir(MOD_DIR):
         return mods
     for fname in os.listdir(MOD_DIR):
-        if not fname.endswith('.json'):
+        if not fname.endswith(".json"):
             continue
         with open(os.path.join(MOD_DIR, fname)) as f:
             data = json.load(f)
-        mods.append(Mod(name=data.get('name', fname), items=data.get('items', []), maps=data.get('maps', [])))
+        mods.append(
+            Mod(
+                name=data.get("name", fname),
+                items=data.get("items", []),
+                maps=data.get("maps", []),
+            )
+        )
     return mods

--- a/src/npc.py
+++ b/src/npc.py
@@ -1,11 +1,13 @@
 from dataclasses import dataclass, field
 from typing import Optional, Set, Tuple, List
 
-from game_map import GameMap
+from .game_map import GameMap
+
 
 @dataclass
 class NPC:
     """Basic non-player character with simple needs."""
+
     name: str
     health: int = 100
     hunger: int = 100
@@ -47,7 +49,9 @@ class NPC:
         if self.diseases:
             self.health = max(0, self.health - len(self.diseases))
 
-    def satisfy(self, rest: int = 0, safety: int = 0, social: int = 0, status: int = 0) -> None:
+    def satisfy(
+        self, rest: int = 0, safety: int = 0, social: int = 0, status: int = 0
+    ) -> None:
         """Increase needs scores without exceeding 100."""
         self.rest = min(100, self.rest + rest)
         self.safety = min(100, self.safety + safety)
@@ -99,7 +103,7 @@ class NPC:
         if target is not None:
             if game_map is None:
                 raise ValueError("game_map required for pathfinding")
-            from pathfinding import find_path
+            from .pathfinding import find_path
 
             path = find_path((self.x, self.y), target, game_map, obstacles)
             if len(path) > 1:

--- a/src/pathfinding.py
+++ b/src/pathfinding.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from heapq import heappush, heappop
 from typing import List, Tuple, Set, Optional
 
-from game_map import GameMap
+from .game_map import GameMap
 
 Coord = Tuple[int, int]
 
@@ -12,8 +12,12 @@ def heuristic(a: Coord, b: Coord) -> int:
     return abs(a[0] - b[0]) + abs(a[1] - b[1])
 
 
-def find_path(start: Coord, goal: Coord, game_map: GameMap,
-              obstacles: Optional[Set[Coord]] = None) -> List[Coord]:
+def find_path(
+    start: Coord,
+    goal: Coord,
+    game_map: GameMap,
+    obstacles: Optional[Set[Coord]] = None,
+) -> List[Coord]:
     """Return a path from start to goal using A* search."""
     obstacles = obstacles or set()
     open_set = []
@@ -37,5 +41,7 @@ def find_path(start: Coord, goal: Coord, game_map: GameMap,
                 continue
             new_cost = cost + 1
             priority = new_cost + heuristic(next_pos, goal)
-            heappush(open_set, (priority, new_cost, next_pos, path + [next_pos]))
+            heappush(
+                open_set, (priority, new_cost, next_pos, path + [next_pos])
+            )
     return []

--- a/src/player.py
+++ b/src/player.py
@@ -1,10 +1,12 @@
 from dataclasses import dataclass, field
-from npc import NPC
-from item import Inventory, Item
+from .npc import NPC
+from .item import Inventory, Item
+
 
 @dataclass
 class Player(NPC):
     """Player character inheriting from NPC with an inventory."""
+
     inventory: Inventory = field(default_factory=Inventory)
 
     def pick_up(self, item: Item) -> None:

--- a/src/save_load.py
+++ b/src/save_load.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import json
 from typing import List, Tuple, Dict, Any, Optional
 
-from player import Player
-from npc import NPC
-from item import Item
-from game_map import GameMap
+from .player import Player
+from .npc import NPC
+from .item import Item
+from .game_map import GameMap
 
 
 def _item_to_dict(item: Item) -> dict:
@@ -105,4 +105,3 @@ def load_game(path: str) -> Tuple[Player, List[NPC], GameMap, Dict[str, Any]]:
 
     story_state = data.get("story_state", {})
     return player, npcs, game_map, story_state
-

--- a/src/story_anchors.py
+++ b/src/story_anchors.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Callable, List
 
 

--- a/src/worldgen.py
+++ b/src/worldgen.py
@@ -12,7 +12,9 @@ ADJACENCY = {
 TILES = list(ADJACENCY.keys())
 
 
-def _neighbors(x: int, y: int, width: int, height: int) -> List[Tuple[int, int]]:
+def _neighbors(
+    x: int, y: int, width: int, height: int
+) -> List[Tuple[int, int]]:
     coords = []
     if x > 0:
         coords.append((x - 1, y))
@@ -55,14 +57,18 @@ def generate_map(width: int, height: int, seed: int | None = None):
         for y in range(height):
             for x in range(width):
                 options = cells[y][x]
-                if len(options) > 1 and (min_opts is None or len(options) < min_opts):
+                if len(options) > 1 and (
+                    min_opts is None or len(options) < min_opts
+                ):
                     min_opts = len(options)
                     target = (x, y)
         if target is None:
             break
         collapse_cell(*target)
 
-    result = [[next(iter(cells[y][x])) for x in range(width)] for y in range(height)]
+    result = [
+        [next(iter(cells[y][x])) for x in range(width)] for y in range(height)
+    ]
     return result
 
 

--- a/tests/test_ai_behavior.py
+++ b/tests/test_ai_behavior.py
@@ -1,8 +1,10 @@
-import os, sys
-sys.path.insert(0, os.path.abspath('src'))
+import os
+import sys
 
-from npc import NPC
-from ai_behavior import select_behavior, Behavior
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.npc import NPC
+from src.ai_behavior import select_behavior, Behavior
 
 
 def test_select_behavior_based_on_needs():

--- a/tests/test_asset_manager.py
+++ b/tests/test_asset_manager.py
@@ -1,9 +1,11 @@
+import json
 import os
 import sys
-import json
 import zipfile
 
-sys.path.insert(0, os.path.abspath('src'))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.asset_manager import download_and_index, ensure_assets, DEFAULT_ASSETS
 
 
 def test_download_and_index_local_zip(tmp_path, monkeypatch):
@@ -14,7 +16,9 @@ def test_download_and_index_local_zip(tmp_path, monkeypatch):
     monkeypatch.setenv('ASSET_TEMP', str(temp_dir))
 
     # Import after env vars so paths are updated
-    from asset_manager import download_and_index
+    from importlib import reload
+    from src import asset_manager as am
+    am = reload(am)
 
     # Create a small zip file to act as the download
     zip_file = tmp_path / 'pack.zip'
@@ -22,7 +26,7 @@ def test_download_and_index_local_zip(tmp_path, monkeypatch):
         zf.writestr('file1.png', 'data')
         zf.writestr('folder/file2.png', 'more')
 
-    download_and_index('testpack', f'file://{zip_file}')
+    am.download_and_index('testpack', f'file://{zip_file}')
 
     dest_zip = temp_dir / 'testpack.zip'
     assert not dest_zip.exists()
@@ -40,9 +44,9 @@ def test_ensure_assets_multiple(tmp_path, monkeypatch):
     monkeypatch.setenv('ASSET_DB', str(db_path))
     monkeypatch.setenv('ASSET_TEMP', str(temp_dir))
 
-    import importlib
-    import asset_manager
-    asset_manager = importlib.reload(asset_manager)
+    from importlib import reload
+    from src import asset_manager
+    asset_manager = reload(asset_manager)
 
     zip1 = tmp_path / 'ui.zip'
     with zipfile.ZipFile(zip1, 'w') as zf:
@@ -71,7 +75,7 @@ def test_ensure_assets_multiple(tmp_path, monkeypatch):
 
 
 def test_default_assets_keys():
-    import asset_manager
+    from src import asset_manager
     keys = set(asset_manager.DEFAULT_ASSETS.keys())
     assert keys == {
         'tiny-town',

--- a/tests/test_cli_seed.py
+++ b/tests/test_cli_seed.py
@@ -1,8 +1,9 @@
 import os
 import sys
-sys.path.insert(0, os.path.abspath('src'))
 
-import main
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src import main
 
 
 def test_parse_args_seed():

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -1,9 +1,11 @@
-import os, sys
-sys.path.insert(0, os.path.abspath('src'))
+import os
+import sys
 
-from item import Item
-from npc import NPC
-import combat
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.item import Item
+from src.npc import NPC
+from src import combat
 
 
 def test_melee_attack_hits(monkeypatch):

--- a/tests/test_crafting.py
+++ b/tests/test_crafting.py
@@ -1,8 +1,10 @@
-import os, sys
-sys.path.insert(0, os.path.abspath('src'))
+import os
+import sys
 
-from item import Item, Inventory
-from crafting import Recipe, craft
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.item import Item, Inventory
+from src.crafting import Recipe, craft
 
 
 def test_craft_success():

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,9 +1,10 @@
 import os
 import sys
-sys.path.insert(0, os.path.abspath('src'))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import pytest
-from item import Item, Inventory
+from src.item import Item, Inventory
 
 
 def test_item_defaults():

--- a/tests/test_llm_integration.py
+++ b/tests/test_llm_integration.py
@@ -1,7 +1,9 @@
-import os, sys
-sys.path.insert(0, os.path.abspath('src'))
+import os
+import sys
 
-from llm_integration import generate_dialogue
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.llm_integration import generate_dialogue
 
 
 def test_generate_dialogue_enabled():

--- a/tests/test_logging_util.py
+++ b/tests/test_logging_util.py
@@ -1,8 +1,9 @@
 import os
 import sys
-sys.path.insert(0, os.path.abspath('src'))
 
-from logging_util import create_logger
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.logging_util import create_logger
 
 
 def test_logger_creates_file(tmp_path):

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1,9 +1,11 @@
-import os, sys
-sys.path.insert(0, os.path.abspath('src'))
+import os
+import sys
 
-from game_map import GameMap
-from worldgen import generate_map
-from npc import NPC
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.game_map import GameMap
+from src.worldgen import generate_map
+from src.npc import NPC
 
 
 def test_get_tile_in_bounds():

--- a/tests/test_modding.py
+++ b/tests/test_modding.py
@@ -1,7 +1,9 @@
-import os, sys
-sys.path.insert(0, os.path.abspath('src'))
+import os
+import sys
 
-from modding import discover_mods
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.modding import discover_mods
 
 
 def test_discover_mods(tmp_path, monkeypatch):
@@ -9,7 +11,7 @@ def test_discover_mods(tmp_path, monkeypatch):
     mod_dir.mkdir()
     mod_file = mod_dir / 'test.json'
     mod_file.write_text('{"name":"test","items":[],"maps":[]}')
-    monkeypatch.setattr('modding.MOD_DIR', str(mod_dir))
+    monkeypatch.setattr('src.modding.MOD_DIR', str(mod_dir))
     mods = discover_mods()
     assert len(mods) == 1
     assert mods[0].name == 'test'

--- a/tests/test_npc.py
+++ b/tests/test_npc.py
@@ -1,6 +1,9 @@
-import os, sys
-sys.path.insert(0, os.path.abspath('src'))
-from npc import NPC
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.npc import NPC
 
 
 def test_npc_defaults():

--- a/tests/test_pathfinding.py
+++ b/tests/test_pathfinding.py
@@ -1,8 +1,10 @@
-import os, sys
-sys.path.insert(0, os.path.abspath('src'))
+import os
+import sys
 
-from game_map import GameMap
-from pathfinding import find_path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.game_map import GameMap
+from src.pathfinding import find_path
 
 
 def make_map(width, height):

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,7 +1,10 @@
-import os, sys
-sys.path.insert(0, os.path.abspath('src'))
-from player import Player
-from item import Item
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.player import Player
+from src.item import Item
 
 
 def test_player_defaults():

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -1,12 +1,13 @@
 import os
 import sys
-sys.path.insert(0, os.path.abspath('src'))
 
-from player import Player
-from item import Item
-from npc import NPC
-from game_map import GameMap
-from save_load import save_game, load_game
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.player import Player
+from src.item import Item
+from src.npc import NPC
+from src.game_map import GameMap
+from src.save_load import save_game, load_game
 
 
 def test_save_load_round_trip(tmp_path):

--- a/tests/test_story_anchors.py
+++ b/tests/test_story_anchors.py
@@ -1,7 +1,9 @@
-import os, sys
-sys.path.insert(0, os.path.abspath('src'))
+import os
+import sys
 
-from story_anchors import StoryAnchor, EventSystem
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.story_anchors import StoryAnchor, EventSystem
 
 
 def test_anchor_triggers_when_condition_met():

--- a/tests/test_worldgen.py
+++ b/tests/test_worldgen.py
@@ -1,7 +1,9 @@
 import os
 import sys
-sys.path.insert(0, os.path.abspath('src'))
-from worldgen import generate_map
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.worldgen import generate_map
 
 
 def test_map_dimensions():
@@ -18,7 +20,7 @@ def test_map_deterministic_seed():
 
 def test_map_respects_adjacency():
     m = generate_map(5, 5, seed=1)
-    from worldgen import ADJACENCY
+    from src.worldgen import ADJACENCY
 
     height = len(m)
     width = len(m[0])


### PR DESCRIPTION
## Summary
- make `src` a proper Python package
- update all internal imports to use package-relative form
- revise tests to import modules from `src`
- ensure root path is added when running tests
- record work in activity log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872802bc00c83329d116d229737ea1d