### PR TITLE
Implement weather effects on NPCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,4 @@ local model. See [docs/llm_integration.md](docs/llm_integration.md).
 ### Weather and Seasons
 
 Use the `WeatherSystem` module to cycle seasons every 30 days and pick random weather. See [docs/weather.md](docs/weather.md).
+NPCs can be affected by weather by passing `WeatherSystem.temperature` to `NPC.tick()`.

--- a/docs/npc.md
+++ b/docs/npc.md
@@ -17,6 +17,8 @@ print(bob.hunger)  # 99
 ```
 
 Calling `tick()` decreases the hunger and thirst values but never below zero.
+If a `weather_temperature` value is supplied to `tick()`, the NPC's body
+temperature will gradually move toward that value.
 
 ## Movement
 

--- a/docs/weather.md
+++ b/docs/weather.md
@@ -16,3 +16,7 @@ Seasons rotate every 30 days in the order Spring, Summer, Autumn and Winter.
 `advance_day()` randomly chooses a weather state based on the season and updates
 the temperature. Winter can produce snow while other seasons produce rain or
 clear skies.
+
+NPCs can react to the current temperature by passing the value from
+`WeatherSystem.temperature` into `NPC.tick()` using the `weather_temperature`
+parameter.

--- a/logs/activity.log
+++ b/logs/activity.log
@@ -149,3 +149,6 @@ Sat Jul 12 17:53:22 UTC 2025 - Ran pytest
 Sat Jul 12 17:53:48 UTC 2025 - Added Pillow dependency
 Sat Jul 12 17:53:57 UTC 2025 - Ran pytest after adding weather system
 Sat Jul 12 17:55:18 UTC 2025 - Added new ticket for weather effects
+Sat Jul 12 18:05:11 UTC 2025 - Started Ticket 62
+Sat Jul 12 18:06:15 UTC 2025 - Added weather interaction to NPCs
+Sat Jul 12 18:06:16 UTC 2025 - Updated docs for weather effects

--- a/src/npc.py
+++ b/src/npc.py
@@ -38,6 +38,7 @@ class NPC:
         social_rate: int = 0,
         status_rate: int = 0,
         temperature_rate: float = 0.0,
+        weather_temperature: float | None = None,
     ) -> None:
         """Advance time by reducing basic needs."""
         self.hunger = max(0, self.hunger - hunger_rate)
@@ -46,6 +47,8 @@ class NPC:
         self.safety = max(0, self.safety - safety_rate)
         self.social = max(0, self.social - social_rate)
         self.status = max(0, self.status - status_rate)
+        if weather_temperature is not None:
+            self.temperature += (weather_temperature - self.temperature) * 0.1
         self.temperature += temperature_rate
         if self.wounds:
             self.health = max(0, self.health - len(self.wounds))

--- a/tests/test_npc.py
+++ b/tests/test_npc.py
@@ -4,6 +4,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from src.npc import NPC
+import pytest
 
 
 def test_npc_defaults():
@@ -63,4 +64,16 @@ def test_npc_impressiveness_and_status():
     n.adjust_status(5)
     assert n.status == 95
     assert n.impressiveness == 5
+
+
+def test_npc_temperature_adjusts_with_cold_weather():
+    n = NPC(name='Bob')
+    n.tick(weather_temperature=0.0)
+    assert n.temperature == pytest.approx(33.3, rel=1e-2)
+
+
+def test_npc_temperature_adjusts_with_hot_weather():
+    n = NPC(name='Bob')
+    n.tick(weather_temperature=40.0)
+    assert n.temperature == pytest.approx(37.3, rel=1e-2)
 

--- a/tickets.md
+++ b/tickets.md
@@ -570,9 +570,9 @@ Document in `docs/equipment.md`.
 - [x] Documented
 Add the Kenney UI Pack RPG Expansion as a runtime-downloadable asset. Index its file list in the asset database.
 ## Ticket 62 - Weather Effects on NPCs
-- [ ] Started
-- [ ] Coded
-- [ ] Tested
-- [ ] Reviewed
-- [ ] Documented
+- [x] Started
+- [x] Coded
+- [x] Tested
+- [x] Reviewed
+- [x] Documented
 Modify NPC.tick to consider weather temperature when adjusting NPC temperature.


### PR DESCRIPTION
## Summary
- account for ambient temperature in `NPC.tick`
- test NPC temperature changes in hot and cold weather
- document NPC reaction to weather and mention it in README
- explain new weather interaction in docs
- log activity and complete Ticket 62

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872a3544de8833297d2a7cb8358519a