### PR TITLE
Implement crafting stations and new game systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,10 @@ The `crafting` module defines simple recipes and a `craft` function to combine i
 
 ### Pathfinding Prototype
 
-The `pathfinding` module provides simple A* search used by `NPC.move` when a
-target is supplied. See [docs/pathfinding.md](docs/pathfinding.md) for details.
+The `pathfinding` module provides A* search used by `NPC.move`. It supports
+optional `avoid` tiles with higher movement cost and a dynamic `is_blocked`
+callback for temporary obstacles. See [docs/pathfinding.md](docs/pathfinding.md)
+for details.
 =======
 ### Logging Utility
 
@@ -111,6 +113,12 @@ Anchors can run an `on_trigger` callback when activated.
 Use `generate_quest` from `procedural_quests` for simple quest generation when
 no LLM is available. See [docs/procedural_quests.md](docs/procedural_quests.md).
 
+### RL Training Prototype
+
+`rl_training.RLTrainer` provides a minimal Q-learning helper used for
+experimental NPC training. See [docs/rl_training.md](docs/rl_training.md) for
+details.
+
 ### Modding and Assets
 
 Mods can be placed under `mods/` and loaded using `modding.discover_mods`. Run
@@ -138,3 +146,8 @@ local model. See [docs/llm_integration.md](docs/llm_integration.md).
 
 Use the `WeatherSystem` module to cycle seasons every 30 days and pick random weather. See [docs/weather.md](docs/weather.md).
 NPCs can be affected by weather by passing `WeatherSystem.temperature` to `NPC.tick()`.
+
+### Day and Night Cycle
+
+`time_cycle.TimeSystem` tracks the current hour. Advance time with
+`advance_hour()` and use `NPC.energy` with `tick()` to model fatigue.

--- a/docs/crafting.md
+++ b/docs/crafting.md
@@ -14,6 +14,18 @@ axe_recipe = Recipe(
 )
 ```
 
+Recipes may also require a specific crafting station:
+
+```python
+from crafting_stations import Anvil
+
+sword_recipe = Recipe(
+    ingredients={'ingot': 1, 'stick': 1},
+    result=Item(name='sword'),
+    station=Anvil,
+)
+```
+
 ## Craft Function
 
 ```python
@@ -28,3 +40,28 @@ new_item = craft(inv, axe_recipe)
 ```
 
 When all ingredients are present, `craft` removes them from the `Inventory` and returns the crafted item which is also added to the inventory. If ingredients are missing, it returns `None` and the inventory is unchanged.
+
+If a recipe specifies a `station`, pass an instance of that station to `craft`:
+
+```python
+from crafting_stations import Anvil
+new_item = craft(inv, sword_recipe, station=Anvil())
+```
+
+Recipes can also require a blueprint item in the inventory and a minimum
+`crafting_skill` on the crafting character. Provide the crafter via the
+`crafter` argument:
+
+```python
+blueprint = Item(name='sword blueprint', is_blueprint=True)
+inv.add(blueprint)
+advanced_recipe = Recipe(
+    ingredients={'ingot': 2},
+    result=Item(name='longsword'),
+    station=Anvil,
+    blueprint='sword blueprint',
+    skill_required=5,
+)
+player.crafting_skill = 5
+new_item = craft(inv, advanced_recipe, station=Anvil(), crafter=player)
+```

--- a/docs/npc.md
+++ b/docs/npc.md
@@ -34,3 +34,13 @@ world = GameMap(5, 5, generate_map(5, 5))
 bob.move(1, 0, world)
 print(bob.x, bob.y)
 ```
+
+## Schedules
+
+NPCs can define a simple daily schedule mapping periods of the day to
+activities. Use `get_activity(hour)` to retrieve the planned activity.
+
+```python
+bob = NPC(name="Bob", schedule={"morning": "work", "night": "sleep"})
+current = bob.get_activity(8)  # 'work'
+```

--- a/docs/pathfinding.md
+++ b/docs/pathfinding.md
@@ -2,7 +2,10 @@
 
 The `pathfinding` module implements a very small A* search over a `GameMap`.
 It returns a list of coordinates from a start to a goal position. Obstacles can
-be provided as a set of blocked coordinates.
+be provided as a set of blocked coordinates. Tiles in an `avoid` set are treated
+with higher movement cost so paths will try to go around them. A dynamic
+`is_blocked` callback can be supplied to check temporary obstacles during
+search.
 
 ```python
 from pathfinding import find_path

--- a/docs/rl_training.md
+++ b/docs/rl_training.md
@@ -1,0 +1,15 @@
+# RL Training Prototype
+
+`rl_training.RLTrainer` implements a minimal Q-learning update used to prototype
+reinforcement learning behaviors for NPCs.
+
+```python
+from rl_training import RLTrainer
+
+trainer = RLTrainer()
+state = (0,)
+next_state = (1,)
+trainer.update(state, action=0, reward=1.0, next_state=next_state)
+```
+
+The trainer stores a `q_table` dictionary mapping states to action values.

--- a/docs/time_cycle.md
+++ b/docs/time_cycle.md
@@ -1,0 +1,4 @@
+# Day and Night Cycle
+
+`time_cycle.TimeSystem` keeps track of the current hour of the day. Calling
+`advance_hour()` increments the hour and wraps around after 23.

--- a/logs/activity.log
+++ b/logs/activity.log
@@ -152,3 +152,11 @@ Sat Jul 12 17:55:18 UTC 2025 - Added new ticket for weather effects
 Sat Jul 12 18:05:11 UTC 2025 - Started Ticket 62
 Sat Jul 12 18:06:15 UTC 2025 - Added weather interaction to NPCs
 Sat Jul 12 18:06:16 UTC 2025 - Updated docs for weather effects
+Sat Jul 12 18:15:02 UTC 2025 - Started Ticket 25: Crafting Stations
+Sat Jul 12 18:16:41 UTC 2025 - Added crafting stations and station requirement
+Sat Jul 12 18:17:04 UTC 2025 - Started Ticket 26: Blueprints and Skill Requirements
+Sat Jul 12 18:18:22 UTC 2025 - Implemented blueprints and crafting skill requirements
+Sat Jul 12 18:19:16 UTC 2025 - Added RL training prototype
+Sat Jul 12 18:20:24 UTC 2025 - Improved pathfinding with avoidance and dynamic obstacles
+Sat Jul 12 18:21:43 UTC 2025 - Added NPC daily schedules
+Sat Jul 12 18:23:36 UTC 2025 - Implemented day/night cycle and energy

--- a/src/crafting.py
+++ b/src/crafting.py
@@ -1,18 +1,41 @@
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Dict, Optional, Type
 
 from .item import Item, Inventory
+from .crafting_stations import Station
+from .npc import NPC
 
 
 @dataclass
 class Recipe:
     ingredients: Dict[str, int]
     result: Item
+    station: Optional[Type[Station]] = None
+    blueprint: Optional[str] = None
+    skill_required: int = 0
 
 
-def craft(inventory: Inventory, recipe: Recipe) -> Optional[Item]:
+def craft(
+    inventory: Inventory,
+    recipe: Recipe,
+    station: Optional[Station] = None,
+    crafter: Optional[NPC] = None,
+) -> Optional[Item]:
     """Attempt to craft an item using ingredients from the inventory.
     Returns the crafted Item if successful, otherwise None."""
+    if recipe.station is not None:
+        if station is None or not isinstance(station, recipe.station):
+            return None
+    if recipe.skill_required > 0:
+        if crafter is None or crafter.crafting_skill < recipe.skill_required:
+            return None
+    if recipe.blueprint is not None:
+        blueprint_found = any(
+            it.name == recipe.blueprint and getattr(it, "is_blueprint", False)
+            for it in inventory.items
+        )
+        if not blueprint_found:
+            return None
     # Count available items by name
     counts: Dict[str, int] = {}
     for it in inventory.items:

--- a/src/crafting_stations.py
+++ b/src/crafting_stations.py
@@ -1,0 +1,19 @@
+class Station:
+    """Base class for crafting stations."""
+    pass
+
+class Anvil(Station):
+    """Anvil crafting station."""
+    pass
+
+class Firepit(Station):
+    """Firepit crafting station."""
+    pass
+
+class Loom(Station):
+    """Loom crafting station."""
+    pass
+
+class Kiln(Station):
+    """Kiln crafting station."""
+    pass

--- a/src/item.py
+++ b/src/item.py
@@ -10,6 +10,7 @@ class Item:
     weight: float = 0.0
     volume: float = 0.0
     durability: int = 100
+    is_blueprint: bool = False
     max_volume: Optional[float] = None
     contents: Optional["Inventory"] = None
 

--- a/src/npc.py
+++ b/src/npc.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Optional, Set, Tuple, List
+from typing import Optional, Set, Tuple, List, Dict
 
 from .animation_state import AnimationState
 
@@ -15,6 +15,7 @@ class NPC:
     hunger: int = 100
     thirst: int = 100
     rest: int = 100
+    energy: int = 100
     safety: int = 100
     social: int = 100
     status: int = 100
@@ -22,6 +23,8 @@ class NPC:
     wounds: List[int] = field(default_factory=list)
     diseases: List[str] = field(default_factory=list)
     impressiveness: int = 0
+    crafting_skill: int = 0
+    schedule: Dict[str, str] = field(default_factory=dict)
     personality_traits: List[str] = field(default_factory=list)
     emotional_state: str = "neutral"
     faction: Optional[str] = None
@@ -34,6 +37,7 @@ class NPC:
         hunger_rate: int = 1,
         thirst_rate: int = 1,
         rest_rate: int = 1,
+        energy_rate: int = 1,
         safety_rate: int = 0,
         social_rate: int = 0,
         status_rate: int = 0,
@@ -44,6 +48,7 @@ class NPC:
         self.hunger = max(0, self.hunger - hunger_rate)
         self.thirst = max(0, self.thirst - thirst_rate)
         self.rest = max(0, self.rest - rest_rate)
+        self.energy = max(0, self.energy - energy_rate)
         self.safety = max(0, self.safety - safety_rate)
         self.social = max(0, self.social - social_rate)
         self.status = max(0, self.status - status_rate)
@@ -56,10 +61,16 @@ class NPC:
             self.health = max(0, self.health - len(self.diseases))
 
     def satisfy(
-        self, rest: int = 0, safety: int = 0, social: int = 0, status: int = 0
+        self,
+        rest: int = 0,
+        safety: int = 0,
+        social: int = 0,
+        status: int = 0,
+        energy: int = 0,
     ) -> None:
         """Increase needs scores without exceeding 100."""
         self.rest = min(100, self.rest + rest)
+        self.energy = min(100, self.energy + energy)
         self.safety = min(100, self.safety + safety)
         self.social = min(100, self.social + social)
         self.status = min(100, self.status + status)
@@ -128,3 +139,17 @@ class NPC:
         if game_map is None or game_map.in_bounds(new_x, new_y):
             self.x = new_x
             self.y = new_y
+
+    def get_activity(self, hour: int) -> str:
+        """Return the scheduled activity for the given hour."""
+        if not self.schedule:
+            return "idle"
+        if 6 <= hour < 12:
+            period = "morning"
+        elif 12 <= hour < 18:
+            period = "afternoon"
+        elif 18 <= hour < 24:
+            period = "evening"
+        else:
+            period = "night"
+        return self.schedule.get(period, "idle")

--- a/src/pathfinding.py
+++ b/src/pathfinding.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from heapq import heappush, heappop
-from typing import List, Tuple, Set, Optional
+from typing import List, Tuple, Set, Optional, Callable
 
 from .game_map import GameMap
 
@@ -17,9 +17,12 @@ def find_path(
     goal: Coord,
     game_map: GameMap,
     obstacles: Optional[Set[Coord]] = None,
+    avoid: Optional[Set[Coord]] = None,
+    is_blocked: Optional[Callable[[Coord], bool]] = None,
 ) -> List[Coord]:
-    """Return a path from start to goal using A* search."""
+    """Return a path from start to goal using A* search with avoidance."""
     obstacles = obstacles or set()
+    avoid = avoid or set()
     open_set = []
     heappush(open_set, (heuristic(start, goal), 0, start, [start]))
     visited: Set[Coord] = set()
@@ -39,7 +42,12 @@ def find_path(
                 continue
             if next_pos in obstacles or next_pos in visited:
                 continue
-            new_cost = cost + 1
+            if is_blocked is not None and is_blocked(next_pos):
+                continue
+            step_cost = 1
+            if next_pos in avoid:
+                step_cost += 4
+            new_cost = cost + step_cost
             priority = new_cost + heuristic(next_pos, goal)
             heappush(
                 open_set, (priority, new_cost, next_pos, path + [next_pos])

--- a/src/rl_training.py
+++ b/src/rl_training.py
@@ -1,0 +1,25 @@
+from collections import defaultdict
+from typing import Tuple, Dict, List
+
+class RLTrainer:
+    """Simple Q-learning trainer for NPC behaviors."""
+
+    def __init__(self) -> None:
+        # q_table[state][action] -> value
+        self.q_table: Dict[Tuple, List[float]] = defaultdict(lambda: [0.0, 0.0, 0.0, 0.0])
+
+    def update(
+        self,
+        state: Tuple,
+        action: int,
+        reward: float,
+        next_state: Tuple,
+        alpha: float = 0.1,
+        gamma: float = 0.9,
+    ) -> None:
+        """Update Q-value for a state-action pair."""
+        best_next = max(self.q_table[next_state])
+        current = self.q_table[state][action]
+        self.q_table[state][action] = current + alpha * (
+            reward + gamma * best_next - current
+        )

--- a/src/time_cycle.py
+++ b/src/time_cycle.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+@dataclass
+class TimeSystem:
+    """Simple day/night cycle tracker."""
+    hour: int = 0
+
+    def advance_hour(self) -> None:
+        self.hour = (self.hour + 1) % 24

--- a/tests/test_crafting.py
+++ b/tests/test_crafting.py
@@ -5,6 +5,8 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from src.item import Item, Inventory
 from src.crafting import Recipe, craft
+from src.crafting_stations import Anvil, Firepit
+from src.npc import NPC
 
 
 def test_craft_success():
@@ -28,3 +30,49 @@ def test_craft_missing_ingredient():
     # wood should still be present
     assert len(inv.items) == 1
     assert inv.items[0].name == 'wood'
+
+
+def test_craft_station_requirement():
+    recipe = Recipe(
+        ingredients={'ingot': 1, 'stick': 1},
+        result=Item(name='sword'),
+        station=Anvil,
+    )
+    inv = Inventory()
+    inv.add(Item(name='ingot'))
+    inv.add(Item(name='stick'))
+    # Missing station
+    assert craft(inv, recipe) is None
+
+    inv = Inventory()
+    inv.add(Item(name='ingot'))
+    inv.add(Item(name='stick'))
+    # Wrong station type
+    assert craft(inv, recipe, station=Firepit()) is None
+
+    inv = Inventory()
+    inv.add(Item(name='ingot'))
+    inv.add(Item(name='stick'))
+    item = craft(inv, recipe, station=Anvil())
+    assert item is not None
+    assert item.name == 'sword'
+
+
+def test_craft_blueprint_and_skill():
+    recipe = Recipe(
+        ingredients={'ingot': 1},
+        result=Item(name='dagger'),
+        station=Anvil,
+        blueprint='dagger blueprint',
+        skill_required=2,
+    )
+    bp = Item(name='dagger blueprint', is_blueprint=True)
+    crafter = NPC(name='smith')
+    crafter.crafting_skill = 2
+
+    inv = Inventory()
+    inv.add(Item(name='ingot'))
+    inv.add(bp)
+    item = craft(inv, recipe, station=Anvil(), crafter=crafter)
+    assert item is not None
+    assert item.name == 'dagger'

--- a/tests/test_npc.py
+++ b/tests/test_npc.py
@@ -77,3 +77,17 @@ def test_npc_temperature_adjusts_with_hot_weather():
     n.tick(weather_temperature=40.0)
     assert n.temperature == pytest.approx(37.3, rel=1e-2)
 
+
+def test_npc_schedule():
+    n = NPC(name='Bob', schedule={'morning': 'work', 'evening': 'sleep'})
+    assert n.get_activity(8) == 'work'
+    assert n.get_activity(22) == 'sleep'
+
+
+def test_npc_energy_tick():
+    n = NPC(name='Bob', energy=10)
+    n.tick(energy_rate=5)
+    assert n.energy == 5
+    n.satisfy(energy=3)
+    assert n.energy == 8
+

--- a/tests/test_pathfinding.py
+++ b/tests/test_pathfinding.py
@@ -23,3 +23,10 @@ def test_find_path_with_obstacle():
     path = find_path((0, 0), (2, 0), m, obstacles)
     assert (1, 0) not in path
     assert path[0] == (0, 0) and path[-1] == (2, 0)
+
+
+def test_find_path_avoid_tiles():
+    m = make_map(3, 3)
+    avoid = {(1, 1)}
+    path = find_path((0, 1), (2, 1), m, avoid=avoid)
+    assert (1, 1) not in path

--- a/tests/test_rl_training.py
+++ b/tests/test_rl_training.py
@@ -1,0 +1,13 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.rl_training import RLTrainer
+
+
+def test_rl_update():
+    trainer = RLTrainer()
+    state = (0,)
+    next_state = (1,)
+    trainer.update(state, action=0, reward=1.0, next_state=next_state)
+    assert trainer.q_table[state][0] > 0

--- a/tests/test_time_cycle.py
+++ b/tests/test_time_cycle.py
@@ -1,0 +1,11 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.time_cycle import TimeSystem
+
+
+def test_advance_hour_wraps():
+    t = TimeSystem(hour=23)
+    t.advance_hour()
+    assert t.hour == 0

--- a/tickets.md
+++ b/tickets.md
@@ -199,53 +199,53 @@ Implement `impressiveness` stat affecting NPC reactions.
 Track social status changes through actions and items.
 
 ## Ticket 25 - Crafting Stations
-- [ ] Started
-- [ ] Coded
-- [ ] Tested
+- [x] Started
+- [x] Coded
+- [x] Tested
 - [ ] Reviewed
-- [ ] Documented
+- [x] Documented
 Add station classes such as `Anvil`, `Firepit`, `Loom`, and `Kiln`.
 Require appropriate station for certain recipes.
 
 ## Ticket 26 - Blueprints and Skill Requirements
-- [ ] Started
-- [ ] Coded
-- [ ] Tested
+- [x] Started
+- [x] Coded
+- [x] Tested
 - [ ] Reviewed
-- [ ] Documented
+- [x] Documented
 Introduce blueprint items and crafting skill levels.
 Some recipes require blueprints or high skill to craft.
 
 ## Ticket 27 - Reinforcement Learning NPCs
-- [ ] Started
-- [ ] Coded
-- [ ] Tested
+- [x] Started
+- [x] Coded
+- [x] Tested
 - [ ] Reviewed
-- [ ] Documented
+- [x] Documented
 Prototype RL-based training for selected NPC behaviors.
 
 ## Ticket 28 - Advanced Pathfinding
-- [ ] Started
-- [ ] Coded
-- [ ] Tested
+- [x] Started
+- [x] Coded
+- [x] Tested
 - [ ] Reviewed
-- [ ] Documented
+- [x] Documented
 Add avoidance and dynamic obstacle handling to pathfinding.
 
 ## Ticket 29 - NPC Daily Schedules
-- [ ] Started
-- [ ] Coded
-- [ ] Tested
+- [x] Started
+- [x] Coded
+- [x] Tested
 - [ ] Reviewed
-- [ ] Documented
+- [x] Documented
 Give NPCs schedules for work, rest and social activities.
 
 ## Ticket 30 - Day/Night Cycle and Energy
-- [ ] Started
-- [ ] Coded
-- [ ] Tested
+- [x] Started
+- [x] Coded
+- [x] Tested
 - [ ] Reviewed
-- [ ] Documented
+- [x] Documented
 Implement a day/night cycle and energy stat affecting actions.
 
 ## Ticket 31 - Documentation Diagrams


### PR DESCRIPTION
## Summary
- add crafting stations and requirements
- support blueprints and crafting skills
- introduce reinforcement learning trainer prototype
- enhance pathfinding with avoidance and dynamic obstacles
- implement NPC schedules, energy stat and day/night cycle
- update docs and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872a5ccf330833292f46d3fdc4f6592