### PR TITLE
Add CLI map size options

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ for details.
 
 Use `logging_util.create_logger` to create loggers for the game. See [docs/logging_util.md](docs/logging_util.md) for details.
 =======
-### CLI Seed Option
+### CLI Options
 
-`src/main.py` includes a command line argument for setting the world generation seed. See [docs/cli_seed.md](docs/cli_seed.md) for usage.
+`src/main.py` accepts options for the world generation seed and map size. See [docs/cli_seed.md](docs/cli_seed.md) for usage.
 =======
 
 ### Save and Load System

--- a/docs/cli_seed.md
+++ b/docs/cli_seed.md
@@ -1,9 +1,11 @@
-# CLI Seed Option
+# CLI Options
 
-The game can take a seed from the command line to deterministically generate the world map.
+The game can take several options from the command line to control map generation.
 
 ```
-python src/main.py --seed 42
+python src/main.py --seed 42 --width 20 --height 15
 ```
 
-When no seed is given, a random value is used.
+* `--seed` sets the world generation seed. A random value is used if omitted.
+* `--width` sets the map width in tiles (default 10).
+* `--height` sets the map height in tiles (default 10).

--- a/logs/activity.log
+++ b/logs/activity.log
@@ -180,3 +180,7 @@ Sat Jul 12 19:02:14 UTC 2025 - Implemented equipment slot features
 Sat Jul 12 19:02:38 UTC 2025 - Marked Tickets 34 and 35 as Reviewed
 Sat Jul 12 19:12:08 UTC 2025 - Reviewed tickets 21, 25-33, 47 and updated planning
 Sat Jul 12 19:12:10 UTC 2025 - All tests pass
+Sat Jul 12 19:19:04 UTC 2025 - Started Ticket 63: CLI Map Size Options
+Sat Jul 12 19:19:59 UTC 2025 - Implement CLI map size options
+Sat Jul 12 19:20:23 UTC 2025 - All tests pass for Ticket 63
+Sat Jul 12 19:20:49 UTC 2025 - Reviewed Ticket 63

--- a/src/main.py
+++ b/src/main.py
@@ -8,13 +8,19 @@ def parse_args(args=None):
     parser.add_argument(
         "--seed", type=int, default=None, help="World generation seed"
     )
+    parser.add_argument(
+        "--width", type=int, default=10, help="Map width"
+    )
+    parser.add_argument(
+        "--height", type=int, default=10, help="Map height"
+    )
     return parser.parse_args(args)
 
 
 def main(args=None):
     """Generate a map using the provided command line arguments."""
     opts = parse_args(args)
-    game_map = generate_map(10, 10, seed=opts.seed)
+    game_map = generate_map(opts.width, opts.height, seed=opts.seed)
     for row in game_map:
         print(" ".join(row))
 

--- a/tests/test_cli_seed.py
+++ b/tests/test_cli_seed.py
@@ -11,6 +11,12 @@ def test_parse_args_seed():
     assert args.seed == 123
 
 
+def test_parse_args_map_size():
+    args = main.parse_args(['--width', '20', '--height', '15'])
+    assert args.width == 20
+    assert args.height == 15
+
+
 def test_parse_args_no_seed():
     args = main.parse_args([])
     assert args.seed is None
@@ -21,8 +27,28 @@ def test_main_passes_seed(monkeypatch):
 
     def fake_generate_map(width, height, seed=None):
         called['seed'] = seed
+        called['width'] = width
+        called['height'] = height
         return []
 
     monkeypatch.setattr(main, 'generate_map', fake_generate_map)
     main.main(['--seed', '55'])
     assert called['seed'] == 55
+    assert called['width'] == 10
+    assert called['height'] == 10
+
+
+def test_main_passes_map_size(monkeypatch):
+    called = {}
+
+    def fake_generate_map(width, height, seed=None):
+        called['width'] = width
+        called['height'] = height
+        called['seed'] = seed
+        return []
+
+    monkeypatch.setattr(main, 'generate_map', fake_generate_map)
+    main.main(['--width', '12', '--height', '8'])
+    assert called['width'] == 12
+    assert called['height'] == 8
+    assert called['seed'] is None

--- a/tickets.md
+++ b/tickets.md
@@ -576,3 +576,11 @@ Add the Kenney UI Pack RPG Expansion as a runtime-downloadable asset. Index its 
 - [x] Reviewed
 - [x] Documented
 Modify NPC.tick to consider weather temperature when adjusting NPC temperature.
+
+## Ticket 63 - CLI Map Size Options
+- [x] Started
+- [x] Coded
+- [x] Tested
+- [x] Reviewed
+- [x] Documented
+Allow specifying map width and height via command line options.


### PR DESCRIPTION
## Summary
- add CLI options for map width and height
- update docs and README for new options
- expand tests for CLI parsing and behaviour
- record work on Ticket 63 in logs

## Testing
- `pip install pillow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872b4a0ec2083328cd3dd35de05d1fe