### PR TITLE
Add asset download helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,13 @@ details.
 
 ### Modding and Assets
 
-Mods can be placed under `mods/` and loaded using `modding.discover_mods`. Run
-`scripts/generate_assets.py` to create placeholder assets. See
-The helper in `asset_manager.ensure_assets` downloads Kenney asset packs (environment, characters and UI) at runtime and saves only their file names in `assets/asset_index.json`. Use `asset_manager.DEFAULT_ASSETS` for the default pack URLs.
+Mods can be placed under `mods/` and loaded using `modding.discover_mods`.
+Run `scripts/generate_assets.py` to create placeholder assets.
+Run `scripts/download_assets.py` to fetch the default Kenney packs and index
+their contents. The helper in `asset_manager.ensure_assets` is used by the
+script and downloads the packs (environment, characters and UI) at runtime,
+saving only their file names in `assets/asset_index.json`.
+Use `asset_manager.DEFAULT_ASSETS` for the default pack URLs.
 [docs/modding.md](docs/modding.md) and [docs/assets.md](docs/assets.md).
 `character_sprites.generate_character` builds a basic appearance by selecting
 sprite layers from the indexed `roguelike-characters` pack. See

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -1,6 +1,8 @@
 # Asset Pipeline
 
-**Status:** Asset packs are not yet integrated. Placeholder graphics will be used until runtime downloads are enabled.
+**Status:** Asset packs are integrated through a simple download script.
+Run `python scripts/download_assets.py` to fetch and index the packs the first
+time you need them.
 
 Run `python scripts/generate_assets.py` to create placeholder sprites in
 `assets/generated`. The script uses the color palette defined in

--- a/docs/build_install.md
+++ b/docs/build_install.md
@@ -20,4 +20,6 @@ pytest -q
 ```
 
 
-**Note:** This project is still in development. Asset packs will be downloaded at runtime once fully integrated.
+**Note:** This project is still in development. Run `python scripts/download_assets.py`
+to download the Kenney asset packs if you want to see real graphics instead of
+the generated placeholders.

--- a/logs/activity.log
+++ b/logs/activity.log
@@ -191,3 +191,6 @@ Sat Jul 12 19:38:02 UTC 2025 - Ran pytest after documentation updates
 Sat Jul 12 19:38:03 UTC 2025 - Marked Ticket 64 as Coded, Tested, Reviewed and Documented
 Sat Jul 12 19:38:52 UTC 2025 - Added pillow to requirements.txt
 Sat Jul 12 19:39:03 UTC 2025 - Completed Ticket 64
+Sat Jul 12 19:45:25 UTC 2025 - Started Ticket 65
+Sat Jul 12 19:46:04 UTC 2025 - Created download_assets script
+Sat Jul 12 19:46:56 UTC 2025 - Added tests and documentation for Ticket 65

--- a/scripts/download_assets.py
+++ b/scripts/download_assets.py
@@ -1,0 +1,10 @@
+from src.asset_manager import ensure_assets, DEFAULT_ASSETS
+
+
+def main() -> None:
+    """Download and index the default asset packs."""
+    ensure_assets(DEFAULT_ASSETS)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_download_assets_script.py
+++ b/tests/test_download_assets_script.py
@@ -1,0 +1,34 @@
+import json
+import os
+import sys
+import zipfile
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from importlib import reload
+from scripts import download_assets
+
+
+def test_download_assets_script(tmp_path, monkeypatch):
+    db_path = tmp_path / 'assets.json'
+    temp_dir = tmp_path / 'tmp'
+    monkeypatch.setenv('ASSET_DB', str(db_path))
+    monkeypatch.setenv('ASSET_TEMP', str(temp_dir))
+
+    # Create a fake asset zip
+    zip_file = tmp_path / 'pack.zip'
+    with zipfile.ZipFile(zip_file, 'w') as zf:
+        zf.writestr('file.png', 'data')
+
+    from src import asset_manager
+    asset_manager = reload(asset_manager)
+    monkeypatch.setattr(asset_manager, 'DEFAULT_ASSETS', {'pack': f'file://{zip_file}'})
+
+    reload(download_assets)
+    download_assets.main()
+
+    assert db_path.exists()
+    with open(db_path) as f:
+        data = json.load(f)
+    assert 'pack' in data
+    assert 'file.png' in data['pack']

--- a/tickets.md
+++ b/tickets.md
@@ -592,3 +592,11 @@ Allow specifying map width and height via command line options.
 - [x] Reviewed
 - [x] Documented
 Add Pillow to requirements.txt and note that asset packs are not yet integrated. Update README and docs to indicate the project is still in development and not ready for deployment.
+
+## Ticket 65 - Asset Pack Integration Script
+- [x] Started
+- [x] Coded
+- [x] Tested
+- [x] Reviewed
+- [x] Documented
+Provide a script to download and index the default asset packs. Update documentation.


### PR DESCRIPTION
## Summary
- add `download_assets.py` script for retrieving asset packs
- document how to run the new script
- mention the script in build instructions and README
- add tests for the new script
- log activity and track progress in tickets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872baafeb408332838efbe37bfaa582